### PR TITLE
fix(Doomfist): make Uppercut not Oneshot everyone

### DIFF
--- a/src/heroes/doomfist/init.opy
+++ b/src/heroes/doomfist/init.opy
@@ -22,7 +22,7 @@ def initDoomfist():
 
     setCustomHp(OW1_DOOMFIST_HEALTH, 0, 0)
     setUltCost(OW1_DOOMFIST_ULT_COST)
-    setBaseDamage(eventPlayer, OW1_MELEE_DAMAGE/OW2_MELEE_DAMAGE) # this is set to 10 because of a bug thats not healing back fully and for 60 degree cone so u dont get too much ult charge from 90 degree
+    setBaseDamage(eventPlayer, OW1_MELEE_DAMAGE/OW2_MELEE_DAMAGE)
 
     initRocketPunch()
     initSlam()

--- a/src/heroes/doomfist/uppercut.opy
+++ b/src/heroes/doomfist/uppercut.opy
@@ -131,7 +131,7 @@ rule "[doomfist/uppercut.opy]: Damage uppercut victims + vfx + uppercut knockbac
     @Condition eventPlayer._last_uppercut_attacker != eventPlayer._uppercut_attacker
 
     # damage
-    damage(eventPlayer, eventPlayer._uppercut_attacker, (OW1_DOOMFIST_UPPERCUT_DAMAGE*50)) # idk why _base_damage_scalar isnt working but it doesnt and it gives u like 13 damage so magic number it is
+    damage(eventPlayer, eventPlayer._uppercut_attacker, OW1_DOOMFIST_UPPERCUT_DAMAGE*OW2_MELEE_DAMAGE/OW1_MELEE_DAMAGE)
     eventPlayer.setEnvironmentalKillCreditor(eventPlayer._uppercut_attacker)
 
     # upercut hit vfx


### PR DESCRIPTION
For some reason, Uppercut deals 1875 damage. This PR should fix this and make it so Doomfist deals 50 damage on uppercut again and not one shot everyone.