### PR TITLE
fix(Doomfist): Punch CD if keep holding Right Click

### DIFF
--- a/src/heroes/doomfist/punch.opy
+++ b/src/heroes/doomfist/punch.opy
@@ -52,10 +52,6 @@ rule "[doomfist/punch.opy]: Initialize rocket punch":
     stopChasingVariable(eventPlayer.punch_charge_time)
     eventPlayer.punch_charge_time = max(OW1_DOOMFIST_PUNCH_CHARGE_TIME_MIN, eventPlayer.punch_charge_time)
 
-    # cooldown
-    waitUntil(not eventPlayer.isFiringSecondaryFire(), Math.INFINITY)
-    eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, OW1_DOOMFIST_PUNCH_COOLDOWN) # workshop bug (doesn't work)
-
 
 # DO NOT switch the order of this rule with the next rule
 # The order is functionally significant


### PR DESCRIPTION
Fixes a issue where if you cancel punch but keep hold right click then after you stop holding, it sets the cooldown, not even sure why this exists to begin with..

Fixes an internal issue in the OW1EM/PJH discord. 
https://discord.com/channels/1125986404212670568/1492636772226568283